### PR TITLE
Add fixture mode for sync script offline testing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Normalize line endings
+* text=auto
+
+# Treat shell scripts as text with LF
+*.sh text eol=lf

--- a/.github/workflows/sync_apple_docs.yml
+++ b/.github/workflows/sync_apple_docs.yml
@@ -1,0 +1,40 @@
+name: Sync Apple Docs
+
+on:
+  schedule:
+    - cron: "0 7 * * *"   # daily 07:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pandoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc
+
+      - name: Run sync
+        run: bash scripts/sync_apple_docs.sh
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(docs): sync Apple docs snapshots"
+          title: "chore(docs): nightly Apple docs sync"
+          body: |
+            Updates local snapshots in `Docs/Apple/` from developer.apple.com.
+            Source URLs: see `docs-config/apple_urls.txt`.
+            Conversion: HTML → Markdown via pandoc.
+          branch: chore/nightly-apple-docs-sync
+          delete-branch: true
+          labels: docs, automated

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# OS
+.DS_Store
+
+# Editors/IDEs
+.idea/
+.vscode/
+
+# Build artifacts
+build/
+dist/
+
+# Cache
+.cache/
+.tmp/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: docs-sync
+docs-sync:
+	@bash scripts/sync_apple_docs.sh

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# apple-docs-sync-template
-Sync a curated set of Apple developer docs into Markdown snapshots for offline/reference use in other repos.
+# Apple Docs Sync Template
+
+[![Apple Docs Sync](https://github.com/${{REPO_OWNER}}/${{REPO_NAME}}/actions/workflows/sync_apple_docs.yml/badge.svg)](https://github.com/${{REPO_OWNER}}/${{REPO_NAME}}/actions/workflows/sync_apple_docs.yml)
+![Latest Tag](https://img.shields.io/github/v/tag/${{REPO_OWNER}}/${{REPO_NAME}}?label=latest%20tag&sort=semver)
+
+Syncs a curated set of Apple developer docs into Markdown snapshots for offline/reference use in other projects.
+
+## How it works
+- URLs are defined in `docs-config/apple_urls.txt` (one line per: `<URL> <output.md>`).
+- `scripts/sync_apple_docs.sh` fetches pages (curl) and converts HTML→Markdown (pandoc) into `Docs/Apple/`.
+- A nightly GitHub Action opens a PR with changes.
+
+## Use in any project
+1. Copy `docs-config/`, `scripts/`, `.github/workflows/sync_apple_docs.yml`, and the `Docs/Apple/` folder (empty is fine).
+2. Add or edit URLs in `docs-config/apple_urls.txt`.
+3. Run locally:
+   ```bash
+   brew install pandoc   # macOS
+   make docs-sync        # or: bash scripts/sync_apple_docs.sh
+   ```
+
+## Local testing without network access
+The sync script can run against lightweight fixtures when outbound network access is unavailable (for example, when using `act` or other CI sandboxes).
+
+```bash
+APPLE_DOCS_FETCH_MODE=fixtures make docs-sync
+```
+
+When running the GitHub Actions workflow locally with [`act`](https://github.com/nektos/act), the script automatically falls back to fixtures because `act` sets the `ACT` environment variable.
+
+You can provide custom fixtures by setting `APPLE_DOCS_FIXTURE_DIR` to a directory containing `<output>.html` files that match entries in `docs-config/apple_urls.txt`.

--- a/docs-config/apple_urls.txt
+++ b/docs-config/apple_urls.txt
@@ -1,0 +1,5 @@
+https://developer.apple.com/documentation/xcode xcode.md
+https://developer.apple.com/design/human-interface-guidelines/ hig.md
+https://developer.apple.com/documentation/technologyoverviews tech-overviews.md
+https://developer.apple.com/documentation/technologyoverviews/app-design-and-ui app-design-ui.md
+https://developer.apple.com/documentation/technologyoverviews/adopting-liquid-glass liquid-glass.md

--- a/scripts/sync_apple_docs.sh
+++ b/scripts/sync_apple_docs.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Sync a curated set of Apple docs into Docs/Apple as Markdown for repository reference.
+# Requires: curl, pandoc
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST="${ROOT}/Docs/Apple"
+LIST="${ROOT}/docs-config/apple_urls.txt"
+FETCH_MODE="${APPLE_DOCS_FETCH_MODE:-network}"
+FIXTURE_DIR="${APPLE_DOCS_FIXTURE_DIR:-${ROOT}/tests/fixtures/apple_docs}"
+USER_AGENT="${APPLE_DOCS_USER_AGENT:-Mozilla/5.0 (Macintosh; Intel Mac OS X 13_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Safari/605.1.15}"
+MAX_RETRIES="${APPLE_DOCS_MAX_RETRIES:-3}"
+RETRY_DELAY="${APPLE_DOCS_RETRY_DELAY:-5}"
+
+if [[ "${FETCH_MODE}" == "network" && -n "${ACT:-}" ]]; then
+  FETCH_MODE="fixtures"
+fi
+
+mkdir -p "${DEST}"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 1; }; }
+need curl
+need pandoc
+
+log() { printf '%s\n' "$*" >&2; }
+
+fetch_html() {
+  local url="$1"
+  local out="$2"
+  local attempt=1
+  local html=""
+
+  case "${FETCH_MODE}" in
+    network)
+      while (( attempt <= MAX_RETRIES )); do
+        log "→ Fetching ${url} (attempt ${attempt}/${MAX_RETRIES})"
+        if html="$(curl --fail --show-error --silent --location --compressed -A "${USER_AGENT}" "${url}")"; then
+          printf '%s' "${html}"
+          return 0
+        fi
+        local status=$?
+        if (( attempt == MAX_RETRIES )); then
+          log "✗ Failed after ${MAX_RETRIES} attempts: curl exit ${status}"
+          return "${status}"
+        fi
+        log "… retrying in ${RETRY_DELAY}s (curl exit ${status})"
+        sleep "${RETRY_DELAY}"
+        (( attempt++ ))
+      done
+      ;;
+    fixtures)
+      local stem
+      stem="$(basename "${out}" .md)"
+      local fixture_path="${FIXTURE_DIR}/${stem}.html"
+      if [[ ! -f "${fixture_path}" ]]; then
+        log "✗ Fixture not found for ${out}: ${fixture_path}"
+        return 1
+      fi
+      log "→ Using fixture ${fixture_path}"
+      cat "${fixture_path}"
+      return 0
+      ;;
+    *)
+      log "Unknown APPLE_DOCS_FETCH_MODE: ${FETCH_MODE}" >&2
+      return 2
+      ;;
+  esac
+}
+
+write_markdown() {
+  local html="$1"
+  local url="$2"
+  local out="$3"
+
+  # Convert HTML -> GitHub Flavored Markdown
+  printf '%s' "${html}" | pandoc -f html -t gfm -o "${DEST}/${out}"
+  {
+    echo
+    echo "> Source: ${url}"
+    echo "> Snapshot: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  } >> "${DEST}/${out}"
+  log "✓ Wrote ${DEST}/${out}"
+}
+
+main() {
+  if [[ ! -f "${LIST}" ]]; then
+    echo "Config list not found: ${LIST}" >&2
+    exit 1
+  fi
+
+  while read -r url out; do
+    [[ -z "${url:-}" || -z "${out:-}" ]] && continue
+    local html_content=""
+    html_content="$(fetch_html "${url}" "${out}")" || {
+      local status=$?
+      exit "${status}"
+    }
+    write_markdown "${html_content}" "${url}" "${out}"
+  done < "${LIST}"
+
+  log "✅ Synced Apple docs to ${DEST}/"
+}
+
+main "$@"

--- a/tests/fixtures/apple_docs/app-design-ui.html
+++ b/tests/fixtures/apple_docs/app-design-ui.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>App Design and UI</title>
+</head>
+<body>
+  <main>
+    <h1>App Design and UI</h1>
+    <p>Learn how to craft delightful interfaces with SwiftUI and UIKit.</p>
+    <h2>Resources</h2>
+    <ul>
+      <li>Interface essentials</li>
+      <li>Patterns and components</li>
+    </ul>
+  </main>
+</body>
+</html>

--- a/tests/fixtures/apple_docs/hig.html
+++ b/tests/fixtures/apple_docs/hig.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Human Interface Guidelines</title>
+</head>
+<body>
+  <main>
+    <h1>Human Interface Guidelines</h1>
+    <p>Design experiences that feel at home on Apple platforms.</p>
+    <h2>Principles</h2>
+    <ol>
+      <li>Clarity</li>
+      <li>Deference</li>
+      <li>Depth</li>
+    </ol>
+  </main>
+</body>
+</html>

--- a/tests/fixtures/apple_docs/liquid-glass.html
+++ b/tests/fixtures/apple_docs/liquid-glass.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Adopting Liquid Glass</title>
+</head>
+<body>
+  <main>
+    <h1>Adopting Liquid Glass</h1>
+    <p>Liquid Glass brings depth and dimensionality to your app designs.</p>
+    <h2>Implementation Notes</h2>
+    <p>Use translucency thoughtfully and highlight key content.</p>
+  </main>
+</body>
+</html>

--- a/tests/fixtures/apple_docs/tech-overviews.html
+++ b/tests/fixtures/apple_docs/tech-overviews.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Technology Overviews</title>
+</head>
+<body>
+  <main>
+    <h1>Technology Overviews</h1>
+    <p>Browse overviews for the latest Apple technologies.</p>
+    <h2>Topics</h2>
+    <p>VisionOS, SwiftUI, Machine Learning, and more.</p>
+  </main>
+</body>
+</html>

--- a/tests/fixtures/apple_docs/xcode.html
+++ b/tests/fixtures/apple_docs/xcode.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Xcode Documentation</title>
+</head>
+<body>
+  <main>
+    <h1>Xcode</h1>
+    <p>Xcode helps you develop great apps for Apple platforms.</p>
+    <h2>Highlights</h2>
+    <ul>
+      <li>Integrated editor</li>
+      <li>Simulator support</li>
+      <li>Swift and Objective-C tooling</li>
+    </ul>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add fixture-based sync mode with retries and automatic fixture fallback when running under act
- document offline usage and provide sample HTML fixtures for each configured Apple doc

## Testing
- `APPLE_DOCS_FETCH_MODE=fixtures make docs-sync`
- `ACT=true make docs-sync`


------
https://chatgpt.com/codex/tasks/task_e_68e0c0718674832b8718b25db15a7db9